### PR TITLE
Get snaps created in Launchpad

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,18 @@
+# Don't include caches, logs and documentation
+*.log
+.circleci
+.codecov
+.git
+.github
+.gitignore
+.vscode
+.docker-project
+cache.sqlite
+renovate.json
+README.md
+HACKING.md
+LICENSE
+
+# Environemnt
+.env
+.env.local

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.env.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM ubuntu:focal
+
+# Install required system packages for our CronJob
+RUN apt-get update && apt-get install --yes --no-install-recommends python3-pip
+
+ADD . .
+RUN pip3 install --no-cache-dir -r requirements.txt
+
+ENTRYPOINT python3 poller.py

--- a/README.md
+++ b/README.md
@@ -1,0 +1,18 @@
+This script is executed regularly in our Kubernetes cluster to trigger builds for snaps that:
+- Parts dependencies defined in the snapcraft.yaml were changed (Only the ones that are GitHub repos)
+- The snap GitHub repo itself was changed since the last build.
+
+This script is a Python version of the [old javascript script](https://github.com/canonical-web-and-design/build.snapcraft.io/blob/master/src/server/scripts/poller.js).
+
+## How it works:
+
+All the script does is:
+
+1. Get all the snaps created with the build.snapcraft.io user, and for each repo, it will:
+2. Verify the content in the repo:
+    1. There is a scraftcraft.yaml
+    2. The snap name in the snapcraft.yaml is valid
+3. Get the date of the last built and skip if the snap was built in the previous 24h
+4. Trigger a build if any of the following condition happen:
+    3. Repository of the snap has changed after the last built.
+    4. Any of the GitHub repos from the parts defined in the snapcraft.yaml has changed since the last build.

--- a/poller.py
+++ b/poller.py
@@ -1,0 +1,37 @@
+#! /usr/bin/env python3
+
+import os
+
+from canonicalwebteam.launchpad import Launchpad
+from requests import Session
+
+launchpad = Launchpad(
+    username="build.snapcraft.io",
+    token=os.getenv("LP_API_TOKEN"),
+    secret=os.getenv("LP_API_TOKEN_SECRET"),
+    session=Session(),
+)
+
+
+def get_all_snaps():
+    """
+    Return all the snaps in Launchpad created by the user build.snapcraft.io
+    """
+    response = launchpad._request(
+        "+snaps",
+        params={"ws.op": "findByOwner", "owner": "/~build.snapcraft.io"},
+    ).json()
+
+    snaps = response["entries"]
+
+    while "next_collection_link" in response:
+        response = launchpad._request(
+            response["next_collection_link"][32:]
+        ).json()
+        snaps.extend(response["entries"])
+
+    return snaps
+
+
+snaps = get_all_snaps()
+print(len(snaps))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+canonicalwebteam.launchpad==0.2.8
+requests==2.23.0


### PR DESCRIPTION
# Done

Get all the snaps from build.snapcraft.io user, https://github.com/canonical-web-and-design/snap-squad/issues/1284

# QA
- Check out this branch
- Create .env.local file and ask me for the content
- Run: `docker build . --tag test`
- Run: `docker run --env-file .env.local test` this will take like 5 minutes
- It will output the number of snaps that we have in Launchpad