### PR TITLE
Use SMTP authentication if available, over TLS

### DIFF
--- a/poller.py
+++ b/poller.py
@@ -175,6 +175,8 @@ if __name__ == "__main__":
 
     # Send email if configured
     smtp_server = os.getenv("SMTP_SERVER")
+    smtp_user = os.getenv("SMTP_USER")
+    smtp_pass = os.getenv("SMTP_PASS")
 
     if smtp_server:
         msg = EmailMessage()
@@ -192,5 +194,10 @@ if __name__ == "__main__":
         )
 
         server = SMTP(smtp_server)
+        if smtp_user and smtp_pass:
+            server.ehlo()
+            server.starttls()
+            server.ehlo()
+            server.login(smtp_user, smtp_pass)
         server.send_message(msg)
         server.quit()


### PR DESCRIPTION
The new SMTP relays replacing smtp.internal only permits sending of mail for authenticated clients. This change allows enabling SMTP authentication if the environment variables SMTP_USER and SMTP_PASS are present.

For SMTP authentication, we also start an encrypted channel rather than sending them over plain text (SMTP's STARTTLS).