### PR TITLE
Ignore parts that use source-commit

### DIFF
--- a/src/github.py
+++ b/src/github.py
@@ -175,10 +175,10 @@ class GitHub:
                     gh_part["url"] = (
                         content["parts"][part].get("source").rstrip(".git")
                     )
-                    gh_part["branch"] = content["parts"][part].get(
-                        "source-branch"
-                    )
-                    gh_part["tag"] = content["parts"][part].get("source-tag")
+                    for revision in ("branch", "tag", "commit"):
+                        gh_part[revision] = content["parts"][part].get(
+                            "source-" + revision
+                        )
                     parts.append(gh_part)
 
         return parts

--- a/src/helper.py
+++ b/src/helper.py
@@ -59,9 +59,9 @@ def has_parts_changed(github, snap_name, parts, last_build, logger):
     for part in parts:
         logger.debug(f"Checking part {part['url']}")
 
-        # We are not supporting GitHub tags
-        if part["tag"]:
-            logger.debug(f"Skipping part becuase is ussing GitHub tags")
+        # We are not supporting GitHub tags or commits
+        if part["tag"] or part["commit"]:
+            logger.debug(f"Skipping part because it is using GitHub tag or commit")
             continue
 
         part_gh_owner, part_gh_repo = part["url"][19:].split("/")


### PR DESCRIPTION
Specifically https://launchpad.net/~build.snapcraft.io/+snap/2c5566d9cd0fad66cd6d03c0241aa293 gets triggered every other day, because it uses "source-commit" which is currently not checked, meaning default branch is checked for movement (which it moves daily) and thus a redundant snap build is triggered every other day.